### PR TITLE
fix bad setting of Y_prev (loop was not looping)

### DIFF
--- a/Chapter03/label_propagation.py
+++ b/Chapter03/label_propagation.py
@@ -54,9 +54,9 @@ if __name__ == '__main__':
 
     while np.linalg.norm(Yt - Y_prev, ord=1) > tolerance:
         P = np.dot(D_rbf_inv, W_rbf)
+        Y_prev = Yt.copy()
         Yt = np.dot(P, Yt)
         Yt[0:nb_samples - nb_unlabeled] = Y[0:nb_samples - nb_unlabeled]
-        Y_prev = Yt.copy()
 
     Y_final = np.sign(Yt)
 


### PR DESCRIPTION
The loop stop condition was always true:
`while np.linalg.norm(Yt - Y_prev, ord=1) > tolerance:`
because we had `Y_prev = Yt.copy()` at the end of the loop, so `np.linalg.norm()`  is always zero.
So only 1 iteration was done.

This fixes also a weird observation in the label propagation result, that is shown in the book  
https://www.safaribooksonline.com/library/view/mastering-machine-learning/9781788621113/444d85ce-b88f-4181-a63a-378aa1da8b17.xhtml

We have two round dots (around (-1, -1.5)). The book mentions that the upper one is corrected by not resetting the labels of the labeled points.
But clearly the lower one should also be a square and is fixed by convergence, with this loop fix.